### PR TITLE
Set shebang to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nagios plugin to monitor ruby applications for security vulnerabilities via [bun
 
 Install the [bundler-audit](https://github.com/rubysec/bundler-audit) gem.
 
-Download the [check_bundle_audit](https://cdn.rawgit.com/tommarshall/nagios-check-bundle-audit/v0.1.0/check_bundle_audit) script and make it executable.
+Download the [check_bundle_audit](https://cdn.rawgit.com/tommarshall/nagios-check-bundle-audit/v0.2.0/check_bundle_audit) script and make it executable.
 
 Define a new `command` in the Nagios config, e.g.
 

--- a/README.md
+++ b/README.md
@@ -71,4 +71,5 @@ define command {
 
 ## Dependencies
 
+* bash
 * [bundler-audit](https://github.com/rubysec/bundler-audit)

--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -1,4 +1,4 @@
-# !/bin/sh
+#!/usr/bin/env bash
 
 #
 # check_bundle_audit - Nagios plugin for monitoring ruby applications for CVEs

--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -9,7 +9,7 @@
 # https://github.com/tommarshall/nagios-plugin-bundle-audit
 #
 
-VERSION=0.1.0
+VERSION=0.2.0
 OK=0
 WARNING=1
 CRITICAL=2


### PR DESCRIPTION
#### Because:

* The check uses shell features that aren't guaranteed to be available
  in `/bin/sh`.

#### This change:

* Updates the shebang.
* Adds `bash` as a dependency in the README.
* Bumps version to 0.2.0.