### PR TITLE
Exit unknown if `bundle-audit update` fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ define command {
  * `unknown`
  * `all` (alias for `low,medium,high,unknown`)
 
+### Troubleshooting
+
+```
+UNKNOWN: Unable to update ruby-advisory-db
+```
+
+`bundler-audit` downloads a copy of the [Ruby Advisory Database](https://github.com/rubysec/ruby-advisory-db) inside the user's home directory. This can cause issues if the user running the script does not have a writable home directory. See [#2](https://github.com/tommarshall/nagios-check-bundle-audit/issues/2) for details on how to resolve this.
+
 ## Dependencies
 
 * bash

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nagios plugin to monitor ruby applications for security vulnerabilities via [bun
 
 Install the [bundler-audit](https://github.com/rubysec/bundler-audit) gem.
 
-Download the [check_bundle_audit](https://cdn.rawgit.com/tommarshall/nagios-check-bundle-audit/v0.2.0/check_bundle_audit) script and make it executable.
+Download the [check_bundle_audit](https://cdn.rawgit.com/tommarshall/nagios-check-bundle-audit/v0.3.0/check_bundle_audit) script and make it executable.
 
 Define a new `command` in the Nagios config, e.g.
 

--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -111,7 +111,10 @@ if [ ! -f "${PROJECT_PATH}/Gemfile.lock" ]; then
 fi
 
 # update the ruby advisory db
-$BUNDLE_AUDIT_PATH update >/dev/null 2>&1
+if ! $BUNDLE_AUDIT_PATH update >/dev/null 2>&1; then
+  echo "UNKNOWN: Unable to update ruby-advisory-db"
+  exit $UNKNOWN
+fi
 
 # run bundle-audit
 REPORT=$(cd $PROJECT_PATH; $BUNDLE_AUDIT_PATH)

--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -9,7 +9,7 @@
 # https://github.com/tommarshall/nagios-plugin-bundle-audit
 #
 
-VERSION=0.2.0
+VERSION=0.3.0
 OK=0
 WARNING=1
 CRITICAL=2

--- a/test/check_bundle_audit.bats
+++ b/test/check_bundle_audit.bats
@@ -32,6 +32,14 @@ load 'test_helper'
   assert_output "UNKNOWN: Unable to find bundle-audit"
 }
 
+@test "exits UNKNOWN if unable update the ruby advisory db" {
+  load_fixture clean
+  HOME='/root'
+  run $BASE_DIR/check_bundle_audit --path $TMP_DIRECTORY
+  assert_failure 3
+  assert_output "UNKNOWN: Unable to update ruby-advisory-db"
+}
+
 @test "exits UNKNOWN if unable to parse report" {
   load_fixture clean
   run $BASE_DIR/check_bundle_audit --path $TMP_DIRECTORY --bundle-audit-path /bin/echo


### PR DESCRIPTION
#### Because:

* `bundle-audit update` downloads a copy of the ruby-advisory-db inside
  the user's home directory. This can cause issues if the user running
  the script does not have a writable home directory.
* If the db fails to update this can result in false positives.

#### This change:

* Check if the update command fails, exit unknown if it does.
* Adds a test for this case.
* Add troubleshooting section to README
* Bumps version to 0.3.0