### PR TITLE
Remove backticks from help block

### DIFF
--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -54,7 +54,7 @@ help() {
 
   Options:
     -p, --path <path>              path to project
-    -b  --bundle-audit-path        path to `bundle-audit` gem
+    -b  --bundle-audit-path        path to bundle-audit gem
     -w, --warning <criticalities>  comma seperated CVE criticalities to treat as WARNING
     -c, --critical <criticalities> comma seperated CVE criticalities to treat as CRITICAL
     -v, --version                  output version


### PR DESCRIPTION
#### Because:

* This was causing `check_bundle_audit --help` to attempt to execute the
  `bundle-audit` command.