### PR TITLE
Use `-V` instead of `-v` for `--version` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ define command {
 -b  --bundle-audit-path        path to `bundle-audit` gem
 -w, --warning <criticalities>  comma seperated CVE criticalities to treat as WARNING
 -c, --critical <criticalities> comma seperated CVE criticalities to treat as CRITICAL
--v, --version                  output version
+-V, --version                  output version
 -h, --help                     output help information
 ```
 

--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -57,7 +57,7 @@ help() {
     -b  --bundle-audit-path        path to bundle-audit gem
     -w, --warning <criticalities>  comma seperated CVE criticalities to treat as WARNING
     -c, --critical <criticalities> comma seperated CVE criticalities to treat as CRITICAL
-    -v, --version                  output version
+    -V, --version                  output version
     -h, --help                     output help information
 
   -c/--critical takes priority over -w/--warning.
@@ -78,7 +78,7 @@ while test $# -ne 0; do
     -b|--bundle-audit-path) BUNDLE_AUDIT_PATH=$1; shift ;;
     -w|--warning) WARNING_STATES=$1; shift ;;
     -c|--critical) CRITICAL_STATES=$1; shift ;;
-    -v|--version) version; exit ;;
+    -V|--version) version; exit ;;
     -h|--help) help; exit ;;
     *)
       echo "UNKNOWN: Unrecognised argument: $ARG"

--- a/test/check_bundle_audit.bats
+++ b/test/check_bundle_audit.bats
@@ -176,8 +176,8 @@ load 'test_helper'
   [[ "$output" == "check_bundle_audit "?.?.? ]]
 }
 
-@test "-v is an alias for --version" {
-  run $BASE_DIR/check_bundle_audit -v
+@test "-V is an alias for --version" {
+  run $BASE_DIR/check_bundle_audit -V
   assert_success
   [[ "$output" == "check_bundle_audit "?.?.? ]]
 }


### PR DESCRIPTION
#### Because:

* The nagios plugin guidelines list `-V` as the offical shorthand alias for `--version`, ref:
  https://nagios-plugins.org/doc/guidelines.html#PLUGOPTIONS

#### Notes:

* `-v` is intended to be reserved as a shorthand for `--verbose`.