### PR TITLE
Add `-i/--ignore` option for ignoring advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+* Add `-i/--ignore` option for specifing advisories to exclude.
+
 ## [v0.5.0] - 2017-03-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ define command {
 
 # set full path to bundle-audit
 ./check_bundle_audit -p /var/www/app -b /usr/local/bin/bundle-audit
+
+# ignore advisories CVE-2016-4658 and CVE-2014-0083
+./check_bundle_audit -p /var/www/app -i "CVE-2016-4658 CVE-2014-0083"
 ```
 
 ### Options
@@ -54,6 +57,7 @@ define command {
 -b  --bundle-audit-path        path to `bundle-audit` gem
 -w, --warning <criticalities>  comma seperated CVE criticalities to treat as WARNING
 -c, --critical <criticalities> comma seperated CVE criticalities to treat as CRITICAL
+-i, --ignore <advisory ID(s)>  space seperated advisories to ignore
 -V, --version                  output version
 -h, --help                     output help information
 ```

--- a/check_bundle_audit
+++ b/check_bundle_audit
@@ -52,11 +52,14 @@ help() {
 
     ./check_bundle_audit -p /var/www/app -b /usr/local/bin/bundle-audit
 
+    ./check_bundle_audit -p /var/www/app -i "CVE-2016-4658 CVE-2014-0083"
+
   Options:
     -p, --path <path>              path to project
     -b  --bundle-audit-path        path to bundle-audit gem
     -w, --warning <criticalities>  comma seperated CVE criticalities to treat as WARNING
     -c, --critical <criticalities> comma seperated CVE criticalities to treat as CRITICAL
+    -i, --ignore <advisory ID(s)>  space seperated advisories to ignore
     -V, --version                  output version
     -h, --help                     output help information
 
@@ -78,6 +81,7 @@ while test $# -ne 0; do
     -b|--bundle-audit-path) BUNDLE_AUDIT_PATH=$1; shift ;;
     -w|--warning) WARNING_STATES=$1; shift ;;
     -c|--critical) CRITICAL_STATES=$1; shift ;;
+    -i|--ignore) IGNORE_ARG="--ignore ${1}"; shift ;;
     -V|--version) version; exit ;;
     -h|--help) help; exit ;;
     *)
@@ -117,7 +121,7 @@ if ! $BUNDLE_AUDIT_PATH update >/dev/null 2>&1; then
 fi
 
 # run bundle-audit
-REPORT=$(cd $PROJECT_PATH; $BUNDLE_AUDIT_PATH)
+REPORT=$(cd $PROJECT_PATH; $BUNDLE_AUDIT_PATH $IGNORE_ARG)
 
 # parse report
 LOW_VULN_COUNT=$(echo "$REPORT" | grep -c 'Criticality: Low')

--- a/test/check_bundle_audit.bats
+++ b/test/check_bundle_audit.bats
@@ -153,6 +153,29 @@ load 'test_helper'
   assert_output "WARNING: 1 vulnerabilities found (1 high, 0 medium, 0 low, 0 unknown)"
 }
 
+# --ignore
+# ------------------------------------------------------------------------------
+@test "--ignore excludes a single specified advisory id" {
+  load_fixture dirty-all
+  run $BASE_DIR/check_bundle_audit -p $TMP_DIRECTORY --ignore "CVE-2014-0083"
+  assert_failure 2
+  assert_output "CRITICAL: 3 vulnerabilities found (1 high, 1 medium, 0 low, 1 unknown)"
+}
+
+@test "--ignore excludes multiple specified advisory ids" {
+  load_fixture dirty-all
+  run $BASE_DIR/check_bundle_audit -p $TMP_DIRECTORY --ignore "CVE-2015-1828 CVE-2015-9097 CVE-2014-0083 CVE-2013-5647"
+  assert_success
+  assert_output "OK: No vulnerabilities found"
+}
+
+@test "-i is an alias for --ignore" {
+  load_fixture dirty-all
+  run $BASE_DIR/check_bundle_audit -p $TMP_DIRECTORY -i "CVE-2014-0083"
+  assert_failure 2
+  assert_output "CRITICAL: 3 vulnerabilities found (1 high, 1 medium, 0 low, 1 unknown)"
+}
+
 # --bundle-audit-path
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
**Because:**

* `bundle-audit` supports an `--ignore`/`-i` argument for ignoring
  specific advisories.
* It'd be useful for `check_bundle_audit` to do the same.

Closes #7 